### PR TITLE
Add token system and display page for QR codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # PS-QR-Code-Generator
-A PrestaShop module which allows the user to create a message stored into a QR code. 
+A PrestaShop module which allows the customer message to be retrieved via a QR code.
 
 ## Installation
 
 1. Copy the `psqrcode` folder into your PrestaShop `modules` directory.
 2. In the PrestaShop back office, go to **Modules > Module Manager** and install **QR Code Message**.
-3. After a customer leaves a message in the order comment section and completes the order, a QR code containing their message will be displayed on the order confirmation page.
+3. When an order is validated a secure token is generated and stored in a new table. A QR code is then shown on the order confirmation page. Scanning the code opens a page that displays the customer's message.
 4. The module will log each hook call in the PrestaShop logs under the `Psqrcode` object type for debugging.

--- a/psqrcode/qr-display.php
+++ b/psqrcode/qr-display.php
@@ -1,0 +1,32 @@
+<?php
+require_once dirname(__DIR__, 2) . '/config/config.inc.php';
+
+$token = Tools::getValue('token');
+if (!$token) {
+    die('Token required');
+}
+
+$token = pSQL($token);
+
+$row = Db::getInstance()->getRow('SELECT id_order FROM ' . _DB_PREFIX_ . 'qr_messages WHERE token = "' . $token . '"');
+
+if (!$row) {
+    die('Invalid token');
+}
+
+$message = Db::getInstance()->getValue('SELECT message FROM ' . _DB_PREFIX_ . 'message WHERE id_order=' . (int) $row['id_order'] . ' ORDER BY date_add DESC');
+
+if (!$message) {
+    die('No message found');
+}
+
+?><!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Message</title>
+</head>
+<body>
+<p><?php echo htmlspecialchars($message, ENT_QUOTES, 'UTF-8'); ?></p>
+</body>
+</html>

--- a/psqrcode/views/templates/hook/orderconfirmation.tpl
+++ b/psqrcode/views/templates/hook/orderconfirmation.tpl
@@ -1,5 +1,5 @@
 <div class="qr-message">
-    <p>{l s='Your message:' mod='psqrcode'}</p>
-    <p>{$customer_message|escape:'html'}</p>
+    <p>{l s='Scan the QR code to view your message.' mod='psqrcode'}</p>
     <img src="{$qr_url}" alt="QR code" />
+    <p><a href="{$display_url|escape:'html'}">{l s='Open link' mod='psqrcode'}</a></p>
 </div>


### PR DESCRIPTION
## Summary
- create a table to store secure tokens
- generate a token on order validation
- point QR codes to a module page showing the message
- add simple page `qr-display.php` for viewing messages
- update template and docs

## Testing
- `php -l psqrcode/psqrcode.php` *(fails: `php` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843fdf60a8083329c63fb6fa98c004e