### PR TITLE
Add QR code display on admin order page

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,4 @@ A PrestaShop module which allows the customer message to be retrieved via a QR c
 2. In the PrestaShop back office, go to **Modules > Module Manager** and install **QR Code Message**.
 3. When an order is validated a secure token is generated and stored in a new table. A QR code is then shown on the order confirmation page. Scanning the code opens a page that displays the customer's message.
 4. The module will log each hook call in the PrestaShop logs under the `Psqrcode` object type for debugging.
+5. A QR code is also displayed on the order details page in the back office for easy reference.


### PR DESCRIPTION
## Summary
- register and implement `displayAdminOrderMain` hook
- display QR code on admin order page using existing template
- document back office order page display in README

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68456a74fd7c8332baa65c7932bb855d