### PR TITLE
Switch to local QR code generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -407,3 +407,4 @@ FodyWeavers.xsd
 
 # Zipped module, for easy checkout to branches without loosing packeted module
 *.zip
+psqrcode/qrcodes/


### PR DESCRIPTION
## Summary
- generate QR codes locally using endroid/qr-code
- save QR images to `qrcodes/`
- store expiry date one month from creation
- ignore generated QR images

## Testing
- `php -l psqrcode/psqrcode.php` *(fails: command not found)*
- `composer validate --no-check-all` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68457415b2088332897db1690150c737