### PR TITLE
Fix cookie not saved between checkout steps

### DIFF
--- a/psqrcode/psqrcode.php
+++ b/psqrcode/psqrcode.php
@@ -101,6 +101,7 @@ class Psqrcode extends Module
             );
             // Store in cookie for later use
             $this->context->cookie->delivery_note = $note;
+            $this->context->cookie->write();
         }
     }
 


### PR DESCRIPTION
## Summary
- ensure the note captured on shipping step gets written to the cookie

## Testing
- `composer install --no-interaction` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845f67764088332ab587bac88db7ddd